### PR TITLE
Even fewer bugs in marschall code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.github.marschall</groupId>
             <artifactId>memoryfilesystem</artifactId>
-            <version>0.7.6</version>
+            <version>0.7.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/de/pfabulist/lindwurm/niotest/MarschallWindowsTest.java
+++ b/src/test/java/de/pfabulist/lindwurm/niotest/MarschallWindowsTest.java
@@ -72,8 +72,8 @@ public class MarschallWindowsTest extends AllTests {
                 attributes().add( attributeBuilding( DosAttributesT.class, "dos", DosFileAttributeView.class, DosFileAttributes.class ).
                                           addAttribute( "hidden", DosFileAttributes::isHidden ).
                                           addAttribute( "archive", DosFileAttributes::isArchive ).
-                                          addAttribute( "system", DosFileAttributes::isSystem )
-                                  // .addAttribute( "readonly", DosFileAttributes::isReadOnly ) not supported by Marschal
+                                          addAttribute( "system", DosFileAttributes::isSystem ).
+                                          addAttribute( "readonly", DosFileAttributes::isReadOnly )
                                   ).
                             remove( "owner", FileOwnerView.class ).next().
                 bugScheme( "RelSymLink", true ).
@@ -85,10 +85,7 @@ public class MarschallWindowsTest extends AllTests {
                 bug( "testSymLinkToUnnormalizedRelPath" ).
                 bug( "testGetFileStoreOfNonExistent" ).
                 bug( "testGetFileStoreOfBrokenSymLink" ).
-                bug( "testPathToUriAndBackIsSame" ).
-                bug( "testPathWithWitespaceToUriAndBack" ).
                 bug( "testAppendAndTruncateExistingThrows" ).
-                nitpick( "testGetPathOtherURI", "different exception" ).
                 bug( "testTransferFromSourceWithLessThanRequestedBytesGetsWhatsThere" ).
                 bug( "testTransferFromPositionBeyondFileSizeDoesNothing" ).
 


### PR DESCRIPTION
With the latest version additional tests in MarschallWindowsTest
now pass.